### PR TITLE
LodashModuleReplacementPluginのshorthandsを有効化

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,7 +68,8 @@ export default {
       }),
     !isDev &&
       new LodashModuleReplacementPlugin({
-        collections: true
+        collections: true,
+        shorthands: true
       }),
     !isDev && new MinifyPlugin()
   ].filter(Boolean)


### PR DESCRIPTION
filterメソッドにてショートハンドラー記法が使えなかったため
▼例
_.filter(users, { 'age': 36, 'active': true });

https://lodash.com/docs/4.17.11#filter